### PR TITLE
Define macro OPENSSL in precompiler flags instead of compiler flags

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -67,26 +67,26 @@ endif
 # Distribuition: headers to compile distribuition
 ###############################################################################
 
-EXTRA_DIST  = $(VERSION_INFO_TERMPLATE)
-EXTRA_DIST += src/Clients.h
-EXTRA_DIST += src/Heap.h
-EXTRA_DIST += src/LinkedList.h
-EXTRA_DIST += src/Log.h
-EXTRA_DIST += src/Messages.h
-EXTRA_DIST += src/MQTTPacket.h
-EXTRA_DIST += src/MQTTPacketOut.h
-EXTRA_DIST += src/MQTTPersistenceDefault.h
-EXTRA_DIST += src/MQTTPersistence.h
-EXTRA_DIST += src/MQTTProtocolClient.h
-EXTRA_DIST += src/MQTTProtocol.h
-EXTRA_DIST += src/MQTTProtocolOut.h
-EXTRA_DIST += src/SocketBuffer.h
-EXTRA_DIST += src/Socket.h
-EXTRA_DIST += src/SSLSocket.h
-EXTRA_DIST += src/StackTrace.h
-EXTRA_DIST += src/Thread.h
-EXTRA_DIST += src/Tree.h
-EXTRA_DIST += src/utf-8.h
+noinst_HEADERS  = $(VERSION_INFO_TERMPLATE)
+noinst_HEADERS += src/Clients.h
+noinst_HEADERS += src/Heap.h
+noinst_HEADERS += src/LinkedList.h
+noinst_HEADERS += src/Log.h
+noinst_HEADERS += src/Messages.h
+noinst_HEADERS += src/MQTTPacket.h
+noinst_HEADERS += src/MQTTPacketOut.h
+noinst_HEADERS += src/MQTTPersistenceDefault.h
+noinst_HEADERS += src/MQTTPersistence.h
+noinst_HEADERS += src/MQTTProtocolClient.h
+noinst_HEADERS += src/MQTTProtocol.h
+noinst_HEADERS += src/MQTTProtocolOut.h
+noinst_HEADERS += src/SocketBuffer.h
+noinst_HEADERS += src/Socket.h
+noinst_HEADERS += src/SSLSocket.h
+noinst_HEADERS += src/StackTrace.h
+noinst_HEADERS += src/Thread.h
+noinst_HEADERS += src/Tree.h
+noinst_HEADERS += src/utf-8.h
 
 ###############################################################################
 # Libraries: names

--- a/Makefile.am
+++ b/Makefile.am
@@ -21,9 +21,15 @@ ACLOCAL_AMFLAGS = -I m4
 # Common precompiler, compiler and linker flags
 ###############################################################################
 
+# AM_CPPFLAGS are added by default to the precompiler flags CPPFLAGS within automake, except there are more special CPPFLAGS
 AM_CPPFLAGS = -I $(srcdir)/src -I src
 # AM_CFLAGS are added by default to the CFLAGS within automake, except there are more special CFLAGS
 AM_CFLAGS =
+
+# Libraries with openssl support need to be build with macro OPENSSL defined.
+libcommon_ssl_la_CPPFLAGS  = $(AM_CPPFLAGS) -DOPENSSL
+libpaho_mqtt3cs_la_CPPFLAGS = $(AM_CPPFLAGS) -DOPENSSL
+libpaho_mqtt3as_la_CFLAGS = $(AM_CPPFLAGS) -DOPENSSL
 
 ###############################################################################
 # Build-time header
@@ -165,30 +171,6 @@ endif # if PAHO_WITH_SSL
 ###############################################################################
 
 #COMMONCFLAGS += -fPIC # do not set this here, because the libtool needs to control it!
-
-libcommon_la_CFLAGS  = $(AM_CFLAGS)
-
-if PAHO_BUILD_SYNC
-libpaho_mqtt3c_la_CFLAGS  = $(AM_CFLAGS)
-endif
-
-if PAHO_BUILD_ASYNC
-libpaho_mqtt3a_la_CFLAGS  = $(AM_CFLAGS)
-endif
-
-if PAHO_WITH_SSL
-
-libcommon_ssl_la_CFLAGS  = $(AM_CFLAGS) -DOPENSSL
-
-if PAHO_BUILD_SYNC
-libpaho_mqtt3cs_la_CFLAGS = $(AM_CFLAGS) -DOPENSSL
-endif
-
-if PAHO_BUILD_ASYNC
-libpaho_mqtt3as_la_CFLAGS = $(AM_CFLAGS) -DOPENSSL
-endif
-
-endif # if PAHO_WITH_SSL
 
 ###############################################################################
 # Libraries: linker flags


### PR DESCRIPTION
- Moved macro definition OPENSSL from target specific CFLAGS to target
  specific CPPFLAGS. Becuase macro definitions should be set in header
  files or precompiler flags.
- Removed empty target specifig CFLAGS variable definitions.

Signed-off-by: Juergen Kosel juergen.kosel@softing.com
