### PR TITLE
Correct order of checks for openssl

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -218,11 +218,11 @@ AC_ARG_WITH(
 )
 
 AS_IF([test "x$with_ssl" = "xyes"], [
-	AC_CHECK_LIB([ssl], [SSL_connect], , AC_MSG_ERROR([missing ssl library]))
-	AC_CHECK_HEADER([openssl/ssl.h], , AC_MSG_ERROR([missing openssl/ssl.h header]))
-
-	AC_CHECK_LIB([crypto], [CRYPTO_num_locks], , AC_MSG_ERROR([missing crypto library]))
 	AC_CHECK_HEADER([openssl/crypto.h], , AC_MSG_ERROR([missing openssl/crypto.h header]))
+	AC_CHECK_LIB([crypto], [CRYPTO_num_locks], , AC_MSG_ERROR([missing crypto library]))
+
+        AC_CHECK_HEADER([openssl/ssl.h], , AC_MSG_ERROR([missing openssl/ssl.h header]))
+	AC_CHECK_LIB([ssl], [SSL_connect], , AC_MSG_ERROR([missing ssl library]))
 ])
 
 AM_CONDITIONAL([PAHO_WITH_SSL], [test "$with_ssl" = yes])


### PR DESCRIPTION
libssl depends on libcrypto. Therefore configure has to be check for
libcrypto before checking libssl. Otherwise the check for libssl
may fail.
Both libraries depend on their header files. So the header files must
be checked earlier than the libaries.

Signed-off-by: Juergen Kosel <juergen.kosel@softing.com>